### PR TITLE
docs(readme): fix example usage to reference valid version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Context check
         id: check
-        uses: trigensoftware/simple-release-action@v1
+        uses: trigensoftware/simple-release-action@v1.0.0
         with:
           workflow: check
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Create or update pull request
-        uses: trigensoftware/simple-release-action@v1
+        uses: trigensoftware/simple-release-action@v1.0.0
         with:
           workflow: pull-request
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Release
-        uses: trigensoftware/simple-release-action@v1
+        uses: trigensoftware/simple-release-action@v1.0.0
         with:
           workflow: release
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey there! 👋

I noticed that the example in the README references:

```yaml
uses: trigensoftware/simple-release-action@v1
```

However, that tag doesn't currently exist in this repo, which causes GitHub Actions to fail with the error:

```
Unable to resolve action `trigensoftware/simple-release-action@v1`, unable to find version `v1`
```

This PR updates the usage example to point to `@v1.0.0`, which is a valid tag and resolves the issue.

Let me know if you'd prefer to create a moving `v1` tag that points to `v1.0.0` (or the latest release) — that would also resolve the issue and help users follow semver-style usage.

Thanks for maintaining this project!
